### PR TITLE
Consistent APIs for dissectors

### DIFF
--- a/examples/tcpdump.py
+++ b/examples/tcpdump.py
@@ -25,29 +25,19 @@ capture_thread.start()
 
 setup_process()
 
-d = WishpyDissectorQueuePython(packet_queue)
-packet_generator = d.run()
+dissector = WishpyDissectorQueuePython(packet_queue)
 
-while True:
-    try:
-        hdr, data, dissected = next(packet_generator)
 
-        pktlen, caplen = hdr[0].len, hdr[0].caplen
+try:
 
-        total_sec = hdr[0].ts.tv_sec + hdr[0].ts.tv_usec/1000000
-
+    for _, _, dissected in dissector.run(count=100):
         print(dissected)
-        #print(dt.strftime(dt.fromtimestamp(total_sec), '%H:%M:%S.%f'),
-        #        pktlen, caplen, binascii.hexlify(bytes(data[0:caplen])))
-    except StopIteration:
-        break
-    except KeyboardInterrupt:
-        print("User interrupted.")
-        try:
-            packet_generator.send('stop')
-        except StopIteration:
-            break
 
+except KeyboardInterrupt:
+    print("User interrupted.")
+
+finally:
+    cleanup_process()
 
 c.stop()
 now = dt.now()
@@ -55,4 +45,3 @@ now = dt.now()
 capture_thread.join()
 
 #print(now - then)
-cleanup_process()

--- a/examples/tshark.py
+++ b/examples/tshark.py
@@ -24,14 +24,13 @@ if __name__ == '__main__':
     dissector = WishpyDissectorFile(input_filepath)
 
     then = dt.now()
-    processed = dissector.run(0)
-    now = dt.now()
-    #print("processed {} packets in {}".format(processed, now - then))
 
-    #print("Performing dissection again to make sure the `epan` state is fine.")
-    then = dt.now()
-    processed = dissector.run(1)
-    now = dt.now()
-    #print("processed {} packets in {}".format(processed, now - then))
+    try:
+        for dissected in dissector.run(count=0, skip=0):
+            print(dissected)
 
-    cleanup_process()
+    except KeyboardInterrupt:
+        cleanup_process()
+
+    now = dt.now()
+


### PR DESCRIPTION
- Now both `WishpyDissectorFile` and `WishpyDissectorPyrhonQueue`
  implement `run()` function as a generator.
- Added a parameter `skip` to `WishpydissectorFile.run` that allows
  one to skip specified number of packets.
- cleaned up `examples/tcpdump.py` and `examples/tshark.py` to work
  with the above changes.
- Now the code looks cleaner - Get a dissector object and do something
  like `for dissected in dissector.run(...)` irrespective of the type of
  the dissector