### PR TITLE
Basic Logging support for wireshark and libpcap wrapper

### DIFF
--- a/examples/tshark.py
+++ b/examples/tshark.py
@@ -5,6 +5,7 @@ import struct
 import socket
 from datetime import datetime as dt
 import warnings
+import logging
 
 _MAX_TO_PROCESS = 10000000
 
@@ -12,6 +13,9 @@ from wishpy.wireshark.lib.dissector import WishpyDissectorFile
 from wishpy.wireshark.lib.dissector import setup_process, cleanup_process
 
 if __name__ == '__main__':
+
+    logger = logging.getLogger()
+    logging.basicConfig()
 
     if not len(sys.argv) >= 2:
         print("Usage: tshark.py <filepath>")

--- a/wishpy/__init__.py
+++ b/wishpy/__init__.py
@@ -1,3 +1,5 @@
 import warnings
-
 warnings.simplefilter('always')
+
+import logging
+_logger = logging.getLogger(__name__)

--- a/wishpy/libpcap/__init__.py
+++ b/wishpy/libpcap/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+_logger = logging.getLogger(__name__)

--- a/wishpy/libpcap/lib/__init__.py
+++ b/wishpy/libpcap/lib/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+_logger = logging.getLogger(__name__)

--- a/wishpy/libpcap/lib/capturer.py
+++ b/wishpy/libpcap/lib/capturer.py
@@ -8,7 +8,7 @@ import logging
 from .libpcap_ext import lib as pcap_lib
 from .libpcap_ext import ffi as pcap_ffi
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class WishpyCapturerOpenError(Exception):
     pass
@@ -134,6 +134,8 @@ class LibpcapCapturer(WishpyCapturer):
                 On Error Condition, `WishpyCapturerCaptureError`.
         """
 
+        _logger.debug("LibpcapCapturer.start")
+
         def capture_callback(user, hdr, data):
             self.__queue.put((hdr, data,))
 
@@ -150,6 +152,7 @@ class LibpcapCapturer(WishpyCapturer):
         Simply calls internal libpcap's `pcap_breakloop`
         """
 
+        _logger.debug("LibpcapCapturer.stop")
         pcap_lib.pcap_breakloop(self.__pcap_handle)
 
     def open(self):
@@ -159,6 +162,8 @@ class LibpcapCapturer(WishpyCapturer):
             parameters during the Constructor, those values are set and
             finally activates the handle.
         """
+
+        _logger.debug("LibpcapCapturer.open")
 
         err_buff = pcap_ffi.new('char [256]')
         handle = pcap_lib.pcap_create(self.__iface.encode(), err_buff)
@@ -204,6 +209,8 @@ class LibpcapCapturer(WishpyCapturer):
             pcap_lib.pcap_close(self.__pcap_handle)
         self.__pcap_activated = False
         self.__pcap_handle = None
+
+        _logger.debug("LibpcapCapturer.close")
 
     def __repr__(self):
         return "LibpcapCapturer iface:{}, snaplen:{}, promisc:{}, timeout:{}".\

--- a/wishpy/libpcap/lib/pcapy.py
+++ b/wishpy/libpcap/lib/pcapy.py
@@ -6,10 +6,12 @@ This module provides `pcapy` (https://github.com/helpsystems/pcapy)
 import warnings
 import sys
 import ipaddress
+import logging
 
 from .libpcap_ext import lib as _pcap_lib
 from .libpcap_ext import ffi as _pcap_ffi
 
+_logger = logging.getLogger(__name__)
 
 class PcapError(Exception):
     pass
@@ -148,7 +150,7 @@ class Reader:
         try:
             pcap_close(self.__pcap_handle)
         except:
-            pass
+            _logger.warning("Reader.close")
         finally:
             self.__pcap_handle = None
 
@@ -499,8 +501,7 @@ class _Dumper:
             try:
                 _pcap_lib.pcap_dump_close(self.__dumper)
             except:
-                ## Log warning
-                pass
+                _logger.warning("Reader.close")
             finally:
                 self.__dumper = None
 

--- a/wishpy/wireshark/__init__.py
+++ b/wishpy/wireshark/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+_logger = logging.getLogger(__name__)

--- a/wishpy/wireshark/lib/__init__.py
+++ b/wishpy/wireshark/lib/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+_logger = logging.getLogger(__name__)


### PR DESCRIPTION
- All the actual logging config should be done in the 'application'
  (take a look at `examples/tshark.py`)
- Added basic _logger to all modules and are logging exceptions and any
  additional logging required