### PR TITLE
Cleaning up unwanted `epan_foo_to_str` functions

### DIFF
--- a/examples/tshark_timed.py
+++ b/examples/tshark_timed.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     try:
         then = time.time()
-        for dissected in dissector.run(count=10000, skip=0):
+        for dissected in dissector.run(count=50000, skip=0):
             pass #print(dissected)
 
         now = time.time()


### PR DESCRIPTION
Cleaned up a number of `epan_foo_to_str` functions as we are now
directly using functions from wireshark's API, we don't need to worry
about having to have those functions.