### PR TITLE
Windows Early Support

### DIFF
--- a/README-windows.md
+++ b/README-windows.md
@@ -1,0 +1,51 @@
+# 'wishpy' on Windows 
+
+**NOTE: This is Very Very Experimental, even for a project this early.** 
+
+# Getting Started 
+
+Unfortunately until such time we figure out how to generated `bdist_wheel` for windows, this document is the only
+hope of getting this working on Windows - Windows 10 specifically. 
+
+Specifically, only `examples/tshark.py` which dissects `PCAP`ish files, works. The Capturing part does not work yet, and is a WIP. 
+
+## Building Wireshark and 'wishpy' 
+
+To get started, one has to start building wireshark from the sources first. This is required because there is no equivalent of `-dev` packages on Windows that I know of. If that exists, may be things will be slightly better. 
+
+To get started, one can follow the instructions [here](https://www.wireshark.org/docs/wsdg_html_chunked/ChSetupWin32.html). Most of the instructions work just fine. There are a few changes we have done. 
+
+1. Follow all steps up to section 2.2.10 - you should have got everything required to build wireshark sources instaled.
+2. Ignore step 2.2.3 and 2.2.8. No need to install Qt and Doctools, we are not going to be building that. What we really need is - to be able to build libraries. 
+3. `chocolaty` installation of `visualstudio2019-workload-nativedesktop` will crib. This is because somehow the final `restart` doesn't work. Just restart the machine. 
+4. Note: by default `chocolaty` installs Python3.8 and the support does not work with Python 3.8. My suspicion is there is some issue with setuptools and Python 3.8 as it is not able to properly determine 64 bits windows to start with. So instead of Python 3.8 installed by Chocolaty, one should install Python 3.7.8 from [python.org](https://www.python.org). Python3.8 is per se not a problem with building wireshark, but will annoy when building the bindings, so it's just best to get a working Python installed.
+5. Instead of Using "Developer Command Prompt", we are using "Developer Power Shell", it's slightly easier to work with.
+6. In Power shell, setup following envirnoment variables. 
+   - `$env:WIRESHARK_BASE_DIR = "C:\wireshark-dev"`
+   - `$env:PLATFORM = "x64"`
+   - `$env:WIRESHARK_TARGET_PLATFORM="win64"`
+7. Edit the `CMakeOptions.txt` file to change `BUILD_wireshark` to `OFF`.
+8. Make the following directory - 
+  - `c:\wsbuild64` 
+9. Right now following directories should be present - 
+  - `c:\wireshark` - git clone of the wireshark repo.
+  - `c:\wsbuild64` - build directory - All the subsequent commands are run in this directory.
+  - `c:\wireshark-dev` - Set above as `WIRESHARK_BASE_DIR`. Wireshark downloads all the required tools and libraries inside this path. 
+10. All subsequent commands are to be run into - `c:\wsbuild64` directory
+11. Generate the wireshark solution file using - 
+    - `cmake -G "Visual Studio 16 2019" -A x64 ..\wireshark` 
+    - `cmake --build . --config Release --target INSTALL`
+12. Last command might need administrative privilages, so can be re-run again by opening Administrator `Developer powershell for visual studio 2019`
+
+13. This should install wireshark libraries and some console tools inside `C:\program files (86)\wireshark`.
+14. Th required `glib-2` dev files are under - `C:\wireshark-dev\wireshark-win64-libs-3.2\vcpkg-export-20190318-win64ws\installed\x64-windows\include` and `C:\wireshark-dev\wireshark-win64-libs-3.2\vcpkg-export-20190318-win64ws\installed\x64-windows\lib` (Required in next step in `wishpy`.) 
+
+15. Now we can simply perform `python setup.py install` inside wishpy. Note: the paths above are right now hard-coded inside the `wishpy/wireshark/src/wireshark3/epan/epan.py` to get them to build. If you deviate from these paths, this file needs to be changed. (This is ugly right now agreed, we'll need to make it better). 
+
+16. If installation succeeds - one can now run `venv\scripts\tshark.py <pcap-file>`.
+
+17. `PATH` environment variable needs to be updated to point to the wireshark and glib-2 libraries. They are the following respectively - 
+    - Wireshark DLL's Path `c:\Program Files (x86)\Wireshark`
+    - glib-2 DLL's Path `C:\wireshark-dev\wireshark-win64-libs-3.2\vcpkg-export-20190318-win64ws\installed\x64-windows\bin`
+
+

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ def find_libwireshark_version():
         return major, minor, True
     except subprocess.CalledProcessError:
         pass
+    except FileNotFoundError:
+        pass
 
 
     if os.path.exists("wireshark-version"):
@@ -32,8 +34,8 @@ def find_libwireshark_version():
 major, minor, is_pkgconfig = find_libwireshark_version()
 
 if major is None or minor is None:
-    major = 2
-    minor = 6
+    major = 3
+    minor = 2
 
 version_str = "{}.{}".format(major, minor)
 
@@ -59,6 +61,10 @@ elif major == 3:
 
 libpcap_ffi_module = 'wishpy/libpcap/src/pcap_builder.py:libpcap_ffi'
 
+all_cffi_modules = [epan_ffi_module]
+if sys.platform != 'win32':
+    all_cffi_modules.append(libpcap_ffi_module)
+
 setup(name='wishpy',
         version='0.0.11',
         description='Python Bindings for Wireshark using cffi',
@@ -68,10 +74,7 @@ setup(name='wishpy',
         license_files=['LICENSE', 'COPYING', 'COPYING-Wireshark', 'LICENSE-libpcap'],
         setup_requires=['cffi>=1.14.0'],
         install_requires=['cffi>=1.14.0'],
-        cffi_modules=[
-            epan_ffi_module,
-            libpcap_ffi_module
-            ],
+        cffi_modules=all_cffi_modules,
         packages=find_packages(),
         scripts=['examples/tshark3.py',
             'examples/tshark2.py',

--- a/wishpy/wireshark/lib/dissector.py
+++ b/wishpy/wireshark/lib/dissector.py
@@ -32,7 +32,8 @@ except:
     if os.getenv('READTHEDOCS', None) is not None:
         _logger.warning("Import Error, but it's okay during RTD Build.")
     else:
-        raise
+        _logger.warning("Import Error, Ignoring for now.")
+        pass #raise
 
 class WishpyErrorInitDissector(Exception):
     """Error raised during initialization of dissector and or dissector session.

--- a/wishpy/wireshark/src/glib/glib_win_h.py
+++ b/wishpy/wireshark/src/glib/glib_win_h.py
@@ -1,0 +1,87 @@
+
+
+glib_h_cdef = """
+
+// From </usr/lib/x86_64-gnu-linux/gconfig.h>
+
+typedef signed char gint8;
+typedef unsigned char guint8;
+typedef signed short gint16;
+typedef unsigned short guint16;
+
+typedef signed int gint32;
+typedef unsigned int guint32;
+#define G_HAVE_GINT64 1          /* deprecated, always true */
+
+typedef signed long long gint64;
+typedef unsigned long long guint64;
+
+typedef signed long long gssize;
+typedef unsigned long long gsize;
+
+// From <glib-2.0/glib/gtypes.h>
+typedef char   gchar;
+typedef short  gshort;
+typedef long   glong;
+typedef int    gint;
+typedef gint   gboolean;
+
+typedef unsigned char   guchar;
+typedef unsigned short  gushort;
+typedef unsigned long   gulong;
+typedef unsigned int    guint;
+
+typedef float   gfloat;
+typedef double  gdouble;
+
+/* Define min and max constants for the fixed size numerical types
+// Following are not allowed - Let's see how to fix this later
+
+#define G_MININT8	((gint8) -0x80)
+#define G_MAXINT8	((gint8)  0x7f)
+#define G_MAXUINT8	((guint8) 0xff)
+
+#define G_MININT16	((gint16) -0x8000)
+#define G_MAXINT16	((gint16)  0x7fff)
+#define G_MAXUINT16	((guint16) 0xffff)
+
+#define G_MININT32	((gint32) -0x80000000)
+#define G_MAXINT32	((gint32)  0x7fffffff)
+#define G_MAXUINT32	((guint32) 0xffffffff)
+
+#define G_MININT64	((gint64) G_GINT64_CONSTANT(-0x8000000000000000))
+#define G_MAXINT64	G_GINT64_CONSTANT(0x7fffffffffffffff)
+#define G_MAXUINT64	G_GUINT64_CONSTANT(0xffffffffffffffff)
+*/
+typedef void* gpointer;
+typedef const void *gconstpointer;
+
+// from <glib-2.0/glib/gslist.h>
+
+typedef struct _GSList GSList;
+
+struct _GSList
+{
+    gpointer data;
+    GSList *next;
+};
+
+// from <glib-2.0/glib/gregex.h>
+typedef struct _GRegex		GRegex;
+
+typedef gint            (*GCompareFunc)         (gconstpointer  a,
+                                                 gconstpointer  b);
+typedef gint            (*GCompareDataFunc)     (gconstpointer  a,
+                                                 gconstpointer  b,
+						 gpointer       user_data);
+typedef gboolean        (*GEqualFunc)           (gconstpointer  a,
+                                                 gconstpointer  b);
+typedef void            (*GDestroyNotify)       (gpointer       data);
+typedef void            (*GFunc)                (gpointer       data,
+                                                 gpointer       user_data);
+typedef guint           (*GHashFunc)            (gconstpointer  key);
+typedef void            (*GHFunc)               (gpointer       key,
+                                                 gpointer       value,
+                                                 gpointer       user_data);
+
+"""

--- a/wishpy/wireshark/src/wireshark3/epan/epan.py
+++ b/wishpy/wireshark/src/wireshark3/epan/epan.py
@@ -1,16 +1,23 @@
+import sys
+
 from cffi import FFI
 try:
     from cffi import PkgConfigError
 except:
     pass
 
-from ...glib.glib_h import glib_h_cdef
+if sys.platform == 'win32':
+    from ...glib.glib_win_h import glib_h_cdef
+    from ...wsutil.nstime_win_h import wsutil_nstime_h_types_cdef
+else:
+    from ...glib.glib_h import glib_h_cdef
+    from ...wsutil.nstime_h import wsutil_nstime_h_types_cdef
+
 from ...glib.garray_h import garray_h_cdef
 from ...glib.glist_h import glist_h_cdef
 from ...glib.gstring_h import glib_gstring_h_types_cdef
 from ...glib.ghash_h import glib_ghash_h_types_cdef
 
-from ...wsutil.nstime_h import wsutil_nstime_h_types_cdef
 from ...wsutil.buffer_h import wsutil_buffer_h_cdef
 from ...wsutil.inet_ipv4_h import wsutil_inet_ipv4_h_cdef
 from ...wsutil.inet_ipv6_h import wsutil_inet_ipv6_h_cdef
@@ -123,17 +130,29 @@ _pkg_name = 'wishpy.wireshark.lib.epan3_ext'
 
 _pkgconfig_libs = ['wireshark']
 
-_libraries = ['glib-2.0', 'wireshark', 'wsutil']
+_libraries = ['glib-2.0', 'wireshark', 'wsutil', 'wiretap']
 
-_extra_compile_args = [
+if sys.platform == 'win32':
+    # FIXME: Remove the hardcoding below. Change following paths to match
+    # Those on your machine.
+    _extra_compile_args = [
+            "-IC:\\Program Files (x86)\\Wireshark\\include\\Wireshark",
+            "-IC:\\wireshark-dev\\wireshark-win64-libs-3.2\\vcpkg-export-20190318-win64ws\\installed\\x64-windows\\include"
+            ]
+    _extra_link_args = [
+            "/LIBPATH:C:\\wireshark-dev\\wireshark-win64-libs-3.2\\vcpkg-export-20190318-win64ws\\installed\\x64-windows\\lib",
+            "/LIBPATH:C:\\Program Files (x86)\\Wireshark"
+        ]
+else:
+    _extra_compile_args = [
         '-I/usr/local/include/wireshark',
         '-I/usr/include/wireshark',
         '-I/usr/include/glib-2.0',
         '-I/usr/lib/x86_64-linux-gnu/glib-2.0/include',
         ]
 
-_extra_link_args = [
-        '-L/usr/local/lib',
+    _extra_link_args = [
+            '-L/usr/local/lib',
         ]
 
 try:
@@ -141,6 +160,6 @@ try:
             extra_link_args=_extra_link_args)
 except PkgConfigError:
     epan_ffi.set_source(_pkg_name, _sources,
-            libraries=_libraries,
             extra_compile_args=_extra_compile_args,
+            libraries=_libraries,
             extra_link_args=_extra_link_args)

--- a/wishpy/wireshark/src/wsutil/nstime_win_h.py
+++ b/wishpy/wireshark/src/wsutil/nstime_win_h.py
@@ -1,0 +1,100 @@
+wsutil_nstime_h_types_cdef = """
+
+/* nstime.h
+ * Definition of data structure to hold time values with nanosecond resolution
+ *
+ * Wireshark - Network traffic analyzer
+ * By Gerald Combs <gerald@wireshark.org>
+ * Copyright 1998 Gerald Combs
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+// stuff from C standard library without having to do lot of including
+typedef long long int time_t; // Taken from /usr/include/x86_64
+
+// From <wsutil/nstime.h>
+
+typedef struct {
+	time_t	secs;
+	int	nsecs;
+} nstime_t;
+
+
+
+"""
+
+wsutil_nstime_h_funcs_cdef = """
+
+
+/* functions */
+
+/** set the given nstime_t to zero */
+extern void nstime_set_zero(nstime_t *nstime);
+
+/** is the given nstime_t currently zero? */
+extern gboolean nstime_is_zero(nstime_t *nstime);
+
+/** set the given nstime_t to (0,maxint) to mark it as "unset"
+ * That way we can find the first frame even when a timestamp
+ * is zero (fix for bug 1056)
+ */
+extern void nstime_set_unset(nstime_t *nstime);
+
+/* is the given nstime_t currently (0,maxint)? */
+extern gboolean nstime_is_unset(const nstime_t *nstime);
+
+/** duplicate the current time
+ *
+ * a = b
+ */
+extern void nstime_copy(nstime_t *a, const nstime_t *b);
+
+/** calculate the delta between two times (can be negative!)
+ *
+ * delta = b-a
+ *
+ * Note that it is acceptable for two or more of the arguments to point at the
+ * same structure.
+ */
+extern void nstime_delta(nstime_t *delta, const nstime_t *b, const nstime_t *a );
+
+/** calculate the sum of two times
+ *
+ * sum = a+b
+ *
+ * Note that it is acceptable for two or more of the arguments to point at the
+ * same structure.
+ */
+extern void nstime_sum(nstime_t *sum, const nstime_t *b, const nstime_t *a );
+
+/** sum += a */
+#define nstime_add(sum, a) nstime_sum(sum, sum, a)
+
+/** sum -= a */
+#define nstime_subtract(sum, a) nstime_delta(sum, sum, a)
+
+/** compare two times are return a value similar to memcmp() or strcmp().
+ *
+ * a > b : > 0
+ * a = b : 0
+ * a < b : < 0
+ */
+extern int nstime_cmp (const nstime_t *a, const nstime_t *b );
+
+/** converts nstime to double, time base is milli seconds */
+extern double nstime_to_msec(const nstime_t *nstime);
+
+/** converts nstime to double, time base is seconds */
+extern double nstime_to_sec(const nstime_t *nstime);
+
+/** converts Windows FILETIME to nstime, returns TRUE on success,
+    FALSE on failure */
+extern gboolean filetime_to_nstime(nstime_t *nstime, guint64 filetime);
+
+/** converts time like Windows FILETIME, but expressed in nanoseconds
+    rather than tenths of microseconds, to nstime, returns TRUE on success,
+    FALSE on failure */
+extern gboolean nsfiletime_to_nstime(nstime_t *nstime, guint64 nsfiletime);
+
+"""


### PR DESCRIPTION
- README-windows Added
- Proper fixes in code for windows support (`unsigned long` in windows
  is 32 bit only, so we need to make it `unsigned long long` (inside
 `glib_win_h.py` and `nstime_win_h.py`
- Since we are not supporting `libpcap` on windows yet, `setup.py` needs
  to be modified accordingly.
- Hardcoded build specific paths added to `epan/epan.py`. This can be
  done way better, but for later.

Right now this is good enough to close and get into master, to be
improved upon.