### PR TITLE
Support for Linux cooked SLL encap for *any* interface

### DIFF
--- a/wishpy/wireshark/lib/dissector.py
+++ b/wishpy/wireshark/lib/dissector.py
@@ -170,7 +170,8 @@ class WishpyDissectorBase:
 
     libpcap_to_wtap_enctpyes = {
             1: 1, # Enctype Ethernet is same
-            127: 23 # Radiotap
+            127: 23, # Radiotap
+            113: 25
     }
     FTREPR_DISPLAY = epan_lib.FTREPR_DISPLAY
     fvalue_to_string_repr = epan_lib.fvalue_to_string_repr


### PR DESCRIPTION
Running our `tcpdump` with `any` interface results in Key error because
the encap key type for `LINUX_COOKED_SLL` was not mapped to
corresponding wtap encap inside `libpcap_to_wtap_enctypes` dict in the
dissector class.